### PR TITLE
Add AT Protocol DID file for Bluesky verification

### DIFF
--- a/public/.well-known/atproto-did
+++ b/public/.well-known/atproto-did
@@ -1,0 +1,1 @@
+did:plc:ean7ppbuulyscdhoxip3dplh


### PR DESCRIPTION
Adds .well-known/atproto-did file to enable domain verification
for AT Protocol/Bluesky at beez.ly.